### PR TITLE
fixing format

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -374,7 +374,7 @@ func TestBooleanExpression(t *testing.T) {
 	}
 
 	if ident.Value != true {
-		t.Errorf("ident.Value not %s. got=%s", true, ident.Value)
+		t.Errorf("ident.Value not %t. got=%t", true, ident.Value)
 	}
 
 	if ident.TokenLiteral() != "true" {


### PR DESCRIPTION
Found another format issue:

```
[0 [10:39][leo@parser]$ go test
# _/home/leo/code/prs/go-monkey/parser
./parser_test.go:377: Errorf format %s has arg true of wrong type bool
FAIL	_/home/leo/code/prs/go-monkey/parser [build failed]

```

Version:
```
[0 [10:41][leo@go-monkey]$ go version
go version go1.10.3 linux/amd64
[0 [10:41][leo@go-monkey]$
```