### PR TITLE
Differentiate p variables of Parser and int type

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -501,16 +501,16 @@ func (p *Parser) peekTokenIs(t token.TokenType) bool {
 }
 
 func (p *Parser) peekPrecedence() int {
-	if p, ok := precedences[p.peekToken.Type]; ok {
-		return p
+	if tokenPrecedence, ok := precedences[p.peekToken.Type]; ok {
+		return tokenPrecedence
 	}
 
 	return LOWEST
 }
 
 func (p *Parser) curPrecedence() int {
-	if p, ok := precedences[p.curToken.Type]; ok {
-		return p
+	if tokenPrecedence, ok := precedences[p.curToken.Type]; ok {
+		return tokenPrecedence
 	}
 
 	return LOWEST


### PR DESCRIPTION
Update to peekPrecedence() and curPrecedence() for clarity due to differing scopes changing p variable

**Start of method:**
variable p is of base receiver `Type *Parser`

**Within if block:**
Scope changes within if block making p variable `Type int`

**Exiting if block:**
After leaving scope of if block returns to `Type *Parser`

Suggestion to change name of variable (currently p) within if block assignment